### PR TITLE
Rdiff-backup-server-install - change $url to the new one bacause the old 

### DIFF
--- a/manifests/definitions/rdiff-backup-server-install.pp
+++ b/manifests/definitions/rdiff-backup-server-install.pp
@@ -1,6 +1,8 @@
 define rdiff-backup::server::install ($ensure=present) {
   $version = "rdiff-backup-${name}"
-  $url = "http://mirror.lihnidos.org/GNU/savannah/rdiff-backup/${version}.tar.gz"
+  $url = "http://ftp.igh.cnrs.fr/pub/nongnu/rdiff-backup/${version}.tar.gz"
+
+
 
   case $ensure {
     present: {


### PR DESCRIPTION
Rdiff-backup-server-install - change $url to the new one bacause the old one didn't work
