### PR TITLE
rdiff-backup: server::install definition improvements

### DIFF
--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -2,29 +2,23 @@ define rdiff-backup::server::install ($ensure=present) {
 
   $version = "rdiff-backup-${name}"
 
-  case $ensure {
-    present: {
-
-      archive::tar-gz{"/opt/rdiff-backup/${version}/.installed":
-        source  => "${params::download_url}${version}.tar.gz",
-        target  => "/opt/rdiff-backup",
-        notify  => Exec["install ${version}"],
-        require => File["/opt/rdiff-backup"],
-      }
-
-      exec {"install ${version}":
-        command     => "cd /opt/rdiff-backup/${version} && python setup.py install --prefix=/opt/rdiff-backup/${version}",
-        unless      => "test -f /opt/rdiff-backup/${version}/bin/rdiff-backup",
-        refreshonly => true,
-        require     => Package["librsync-devel", "python-devel"],
-      }
-    }
-
-    absent: {
-      file{"/opt/rdiff-backup/${version}":
-        ensure => absent,
-        force => true,
-      }
-    }
+  archive{"${version}":
+    ensure   => $ensure,
+    checksum => false,
+    url      => "${params::download_url}${version}.tar.gz",
+    target   => '/opt/rdiff-backup',
+    notify   => $ensure ? {
+      present => Exec["install ${version}"],
+      default => undef
+    },
+    require  => File["/opt/rdiff-backup"],
   }
+
+  exec {"install ${version}":
+    command     => "cd /opt/rdiff-backup/${version} && python setup.py install --prefix=/opt/rdiff-backup/${version}",
+    unless      => "test -f /opt/rdiff-backup/${version}/bin/rdiff-backup",
+    refreshonly => true,
+    require     => Package["librsync-devel", "python-devel"],
+  }
+
 }


### PR DESCRIPTION
- use archive instead legacy archive::tar-gz
- simplify the way to remove a rdiff-backup version
